### PR TITLE
Add daily puzzle game mode with scoring and statistics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SinglePlayerGame from "./views/singlePlayer/game";
+import DailyGame from "./views/daily/game";
 import { Menu } from "./views/menu";
 import { Provider } from "react-redux";
 import { store } from "./store";
@@ -15,6 +16,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Menu/>} />
             <Route path="/single_player" element={<SinglePlayerGame/>} />
+            <Route path="/daily" element={<DailyGame/>} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/src/components/game/board/index.tsx
+++ b/src/components/game/board/index.tsx
@@ -3,18 +3,22 @@ import Card from "components/game/card";
 import "./index.css";
 import { useSelector } from "react-redux";
 import { ReduxState } from "reducers";
+import { Deck } from "deckBuilder/types";
 
 interface Props {
   board: string[];
   selected: string[];
   hint?: string[];
   onSelect: (id: string) => void;
+  /** Overrides the redux-selected deck (used by modes with a fixed deck). */
+  deck?: Deck;
 }
 
 export const Board = (props: Props) => {
-  const customDeck = useSelector(
+  const reduxDeck = useSelector(
     (state: ReduxState) => state.singlePlayer.deck
   );
+  const customDeck = props.deck ?? reduxDeck;
 
   return (
     <div className="board container">

--- a/src/components/game/previousSelection/index.tsx
+++ b/src/components/game/previousSelection/index.tsx
@@ -1,18 +1,22 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 import { ReduxState } from "reducers";
+import { Deck } from "deckBuilder/types";
 import Card from "components/game/card";
 import "./index.css";
 
 interface Props {
   cards: string[];
   message: string;
+  /** Overrides the redux-selected deck (used by modes with a fixed deck). */
+  deck?: Deck;
 }
 
-export const PreviousSelection = ({cards, message}: Props) => {
-  const deck = useSelector(
+export const PreviousSelection = ({cards, message, deck: deckOverride}: Props) => {
+  const reduxDeck = useSelector(
     (state: ReduxState) => state.singlePlayer.deck
   );
+  const deck = deckOverride ?? reduxDeck;
   if (cards.length <= 0) {
     return null;
   }

--- a/src/daily/__tests__/date.test.ts
+++ b/src/daily/__tests__/date.test.ts
@@ -1,0 +1,30 @@
+import { getDateKey, msUntilNextMidnight, yesterdayKey } from "../date";
+
+test("getDateKey zero-pads month and day", () => {
+  expect(getDateKey(new Date(2026, 0, 5))).toEqual("2026-01-05");
+  expect(getDateKey(new Date(2026, 11, 31))).toEqual("2026-12-31");
+});
+
+test("yesterdayKey handles plain days", () => {
+  expect(yesterdayKey("2026-07-28")).toEqual("2026-07-27");
+});
+
+test("yesterdayKey crosses month boundaries", () => {
+  expect(yesterdayKey("2026-03-01")).toEqual("2026-02-28");
+  expect(yesterdayKey("2024-03-01")).toEqual("2024-02-29");
+});
+
+test("yesterdayKey crosses year boundaries", () => {
+  expect(yesterdayKey("2026-01-01")).toEqual("2025-12-31");
+});
+
+test("msUntilNextMidnight is positive and at most 24 hours", () => {
+  const ms = msUntilNextMidnight(new Date(2026, 6, 28, 15, 30, 12));
+  expect(ms).toBeGreaterThan(0);
+  expect(ms).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+});
+
+test("msUntilNextMidnight just before midnight", () => {
+  const ms = msUntilNextMidnight(new Date(2026, 6, 28, 23, 59, 59));
+  expect(ms).toEqual(1000);
+});

--- a/src/daily/__tests__/deck.test.tsx
+++ b/src/daily/__tests__/deck.test.tsx
@@ -1,0 +1,10 @@
+import { createDailyDeck } from "../deck";
+
+test("the daily deck is a fixed 27-card, 3-feature deck", () => {
+  const deck = createDailyDeck();
+  expect(deck.features.length).toEqual(3);
+  expect(deck.numOptions).toEqual(3);
+  expect(Object.keys(deck.cards).length).toEqual(27);
+  expect(deck.cards["0_0_0"]).toBeDefined();
+  expect(deck.cards["2_2_2"]).toBeDefined();
+});

--- a/src/daily/__tests__/schedule.test.ts
+++ b/src/daily/__tests__/schedule.test.ts
@@ -1,0 +1,66 @@
+import {
+  DAILY_PUZZLE_SCHEDULE,
+  DEFAULT_DAILY_PUZZLE,
+  DailyPuzzleDefinition,
+  DailyPuzzleSchedule,
+  getPuzzleForDate,
+  resolvePuzzleForDate,
+} from "../schedule";
+import { createDailyDeck } from "../deck";
+
+const puzzle = (name: string): DailyPuzzleDefinition => ({
+  name,
+  createDeck: createDailyDeck,
+});
+
+const schedule: DailyPuzzleSchedule = {
+  "2024-07-28": puzzle("july 2024"),
+  "2025-07-28": puzzle("july 2025"),
+  "2026-07-28": puzzle("july 2026"),
+  "2028-07-28": puzzle("july 2028"),
+  "2025-12-25": puzzle("christmas 2025"),
+};
+
+test("the exact year-month-day entry wins", () => {
+  expect(resolvePuzzleForDate(schedule, "2026-07-28")!.name).toEqual(
+    "july 2026"
+  );
+});
+
+test("a missing year falls back to the same day from the most recent earlier year", () => {
+  expect(resolvePuzzleForDate(schedule, "2027-07-28")!.name).toEqual(
+    "july 2026"
+  );
+  expect(resolvePuzzleForDate(schedule, "2026-12-25")!.name).toEqual(
+    "christmas 2025"
+  );
+});
+
+test("entries for future years never leak into earlier dates", () => {
+  // 2028 is defined but the current year is 2027: only 2026 and older count
+  expect(resolvePuzzleForDate(schedule, "2027-07-28")!.name).toEqual(
+    "july 2026"
+  );
+  expect(resolvePuzzleForDate(schedule, "2024-12-25")).toBeNull();
+});
+
+test("other days in the month do not match", () => {
+  expect(resolvePuzzleForDate(schedule, "2026-07-29")).toBeNull();
+  expect(resolvePuzzleForDate(schedule, "2026-08-28")).toBeNull();
+});
+
+test("an undefined day resolves to null", () => {
+  expect(resolvePuzzleForDate({}, "2026-07-28")).toBeNull();
+});
+
+test("getPuzzleForDate falls back to the default fixed deck", () => {
+  // the checked-in schedule starts empty, so any date gets the default
+  expect(Object.keys(DAILY_PUZZLE_SCHEDULE).length).toEqual(0);
+  expect(getPuzzleForDate("2026-07-28")).toBe(DEFAULT_DAILY_PUZZLE);
+});
+
+test("the default puzzle builds the fixed 27-card deck", () => {
+  const deck = DEFAULT_DAILY_PUZZLE.createDeck();
+  expect(deck.features.length).toEqual(3);
+  expect(Object.keys(deck.cards).length).toEqual(27);
+});

--- a/src/daily/__tests__/scoring.test.ts
+++ b/src/daily/__tests__/scoring.test.ts
@@ -1,0 +1,25 @@
+import {
+  computeScore,
+  penaltySeconds,
+  HINT_PENALTY_SECONDS,
+  WRONG_GUESS_PENALTY_SECONDS,
+} from "../scoring";
+
+test("a clean game scores its elapsed time", () => {
+  expect(
+    computeScore({ elapsedSeconds: 272, wrongGuesses: 0, hintsUsed: 0 })
+  ).toEqual(272);
+});
+
+test("wrong guesses and hints add their penalties", () => {
+  expect(
+    computeScore({ elapsedSeconds: 100, wrongGuesses: 2, hintsUsed: 1 })
+  ).toEqual(100 + 2 * WRONG_GUESS_PENALTY_SECONDS + HINT_PENALTY_SECONDS);
+});
+
+test("penaltySeconds only counts penalties", () => {
+  expect(penaltySeconds({ wrongGuesses: 3, hintsUsed: 2 })).toEqual(
+    3 * WRONG_GUESS_PENALTY_SECONDS + 2 * HINT_PENALTY_SECONDS
+  );
+  expect(penaltySeconds({ wrongGuesses: 0, hintsUsed: 0 })).toEqual(0);
+});

--- a/src/daily/__tests__/share.test.ts
+++ b/src/daily/__tests__/share.test.ts
@@ -1,0 +1,60 @@
+import { copyToClipboard, formatShareText, formatTime } from "../share";
+
+test("formatTime formats minutes and seconds", () => {
+  expect(formatTime(0)).toEqual("0:00");
+  expect(formatTime(61)).toEqual("1:01");
+  expect(formatTime(599)).toEqual("9:59");
+});
+
+test("formatTime includes hours only past an hour", () => {
+  expect(formatTime(3600)).toEqual("1:00:00");
+  expect(formatTime(3661)).toEqual("1:01:01");
+});
+
+test("formatTime clamps negatives and fractions", () => {
+  expect(formatTime(-5)).toEqual("0:00");
+  expect(formatTime(61.9)).toEqual("1:01");
+});
+
+test("formatShareText produces the shareable summary", () => {
+  expect(
+    formatShareText({
+      dateKey: "2026-07-28",
+      scoreSeconds: 322,
+      wrongGuesses: 2,
+      hintsUsed: 1,
+      currentStreak: 3,
+    })
+  ).toEqual(
+    "GeneralSet Daily 2026-07-28\n⏱️ 5:22 (2 wrong · 1 hint)\n🔥 Streak: 3"
+  );
+});
+
+test("formatShareText pluralizes hints", () => {
+  const text = formatShareText({
+    dateKey: "2026-07-28",
+    scoreSeconds: 60,
+    wrongGuesses: 0,
+    hintsUsed: 2,
+    currentStreak: 1,
+  });
+  expect(text).toContain("2 hints");
+});
+
+test("copyToClipboard uses the clipboard API when available", async () => {
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+  await expect(copyToClipboard("hello")).resolves.toBe(true);
+  expect(writeText).toHaveBeenCalledWith("hello");
+});
+
+test("copyToClipboard reports failure when every path fails", async () => {
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockRejectedValue(new Error("denied")) },
+  });
+  const execCommand = jest.fn(() => {
+    throw new Error("unsupported");
+  });
+  (document as any).execCommand = execCommand;
+  await expect(copyToClipboard("hello")).resolves.toBe(false);
+});

--- a/src/daily/__tests__/storage.test.ts
+++ b/src/daily/__tests__/storage.test.ts
@@ -1,0 +1,121 @@
+import {
+  DEFAULT_STATS,
+  computeUpdatedStats,
+  loadGameState,
+  loadStats,
+  newGameState,
+  parseGameState,
+  parseStats,
+  saveGameState,
+  saveStats,
+} from "../storage";
+
+const gameState = {
+  dateKey: "2026-07-28",
+  elapsedSeconds: 120,
+  wrongGuesses: 2,
+  hintsUsed: 1,
+  completed: false,
+  finalScoreSeconds: null,
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test("game state round-trips through localStorage", () => {
+  saveGameState(gameState);
+  expect(loadGameState("2026-07-28")).toEqual(gameState);
+});
+
+test("a previous day's saved game is discarded", () => {
+  saveGameState(gameState);
+  expect(loadGameState("2026-07-29")).toBeNull();
+});
+
+test("corrupt game state is discarded", () => {
+  expect(parseGameState("not json{", "2026-07-28")).toBeNull();
+  expect(parseGameState('{"dateKey":"2026-07-28"}', "2026-07-28")).toBeNull();
+  expect(parseGameState(null, "2026-07-28")).toBeNull();
+});
+
+test("stats round-trip through localStorage", () => {
+  const stats = {
+    completions: 5,
+    currentStreak: 3,
+    maxStreak: 4,
+    bestScoreSeconds: 200,
+    lastCompletedDateKey: "2026-07-27",
+  };
+  saveStats(stats);
+  expect(loadStats()).toEqual(stats);
+});
+
+test("corrupt or missing stats fall back to defaults", () => {
+  expect(parseStats(null)).toEqual(DEFAULT_STATS);
+  expect(parseStats("not json{")).toEqual(DEFAULT_STATS);
+  expect(parseStats('{"completions":"five"}')).toEqual(DEFAULT_STATS);
+});
+
+test("first ever completion starts a streak of 1", () => {
+  const updated = computeUpdatedStats(DEFAULT_STATS, "2026-07-28", 300);
+  expect(updated).toEqual({
+    completions: 1,
+    currentStreak: 1,
+    maxStreak: 1,
+    bestScoreSeconds: 300,
+    lastCompletedDateKey: "2026-07-28",
+  });
+});
+
+test("completing on consecutive days extends the streak", () => {
+  const day1 = computeUpdatedStats(DEFAULT_STATS, "2026-07-27", 300);
+  const day2 = computeUpdatedStats(day1, "2026-07-28", 250);
+  expect(day2.currentStreak).toEqual(2);
+  expect(day2.maxStreak).toEqual(2);
+  expect(day2.completions).toEqual(2);
+  expect(day2.bestScoreSeconds).toEqual(250);
+});
+
+test("a missed day resets the streak but keeps max streak and best score", () => {
+  const before = {
+    completions: 4,
+    currentStreak: 4,
+    maxStreak: 4,
+    bestScoreSeconds: 180,
+    lastCompletedDateKey: "2026-07-25",
+  };
+  const after = computeUpdatedStats(before, "2026-07-28", 400);
+  expect(after.currentStreak).toEqual(1);
+  expect(after.maxStreak).toEqual(4);
+  expect(after.bestScoreSeconds).toEqual(180);
+  expect(after.completions).toEqual(5);
+});
+
+test("recording the same day twice is a no-op", () => {
+  const once = computeUpdatedStats(DEFAULT_STATS, "2026-07-28", 300);
+  const twice = computeUpdatedStats(once, "2026-07-28", 100);
+  expect(twice).toEqual(once);
+});
+
+test("localStorage failures degrade to defaults instead of throwing", () => {
+  const getItem = jest
+    .spyOn(Storage.prototype, "getItem")
+    .mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+  const setItem = jest
+    .spyOn(Storage.prototype, "setItem")
+    .mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+  try {
+    expect(loadGameState("2026-07-28")).toBeNull();
+    expect(loadStats()).toEqual(DEFAULT_STATS);
+    expect(() => saveGameState(newGameState("2026-07-28"))).not.toThrow();
+    expect(() => saveStats(DEFAULT_STATS)).not.toThrow();
+  } finally {
+    getItem.mockRestore();
+    setItem.mockRestore();
+  }
+});

--- a/src/daily/date.ts
+++ b/src/daily/date.ts
@@ -1,0 +1,21 @@
+const pad = (n: number): string => (n < 10 ? `0${n}` : `${n}`);
+
+/**
+ * Local calendar date key ("2026-07-28"). Uses local getters, never
+ * toISOString: the puzzle must roll over at the player's midnight, not UTC's.
+ */
+export const getDateKey = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
+/** Date key of the day before `dateKey`. Anchored at noon so DST shifts can't skip a day. */
+export const yesterdayKey = (dateKey: string): string => {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const noon = new Date(year, month - 1, day, 12);
+  noon.setDate(noon.getDate() - 1);
+  return getDateKey(noon);
+};
+
+/** Milliseconds until the next local midnight (when the next puzzle unlocks). */
+export const msUntilNextMidnight = (now: Date): number =>
+  new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime() -
+  now.getTime();

--- a/src/daily/deck.tsx
+++ b/src/daily/deck.tsx
@@ -1,0 +1,19 @@
+import GeometricDeckGenerator from "deckBuilder/GeometricDeckGenerator";
+import { GeneratedDeckMetaData } from "deckBuilder/features";
+import { Deck } from "deckBuilder/types";
+
+/**
+ * The fixed deck every daily game uses (the menu's "Circles" symbol deck):
+ * 3 features x 3 options = 27 cards with a 9-card board, a quick daily-sized
+ * game. Fixed so completion times are comparable between players.
+ */
+export const DAILY_DECK_METADATA: GeneratedDeckMetaData = {
+  shapes: ["Circle - Quarter", "Circle - Semi", "Circle - Three Quarter"],
+  colors: ["Red", "Olive", "Blue"],
+  numbers: [3, 6, 9],
+};
+
+export const createDailyDeck = (): Deck =>
+  new GeometricDeckGenerator(DAILY_DECK_METADATA, undefined, {
+    idPrefix: "daily",
+  });

--- a/src/daily/schedule.ts
+++ b/src/daily/schedule.ts
@@ -1,0 +1,97 @@
+import { Deck } from "deckBuilder/types";
+import { createDailyDeck } from "./deck";
+
+export interface DailyPuzzleDefinition {
+  /** Shown in the daily game header so players know which puzzle they got. */
+  name: string;
+  /**
+   * Builds the deck for this puzzle. Any Deck works: a generated symbol deck
+   * (GeometricDeckGenerator) or a pre-rendered image deck (PresetDeck). Give
+   * generated decks a unique idPrefix so their SVG ids never collide.
+   */
+  createDeck: () => Deck;
+}
+
+/** Puzzle definitions keyed by local date, "YYYY-MM-DD". */
+export interface DailyPuzzleSchedule {
+  [dateKey: string]: DailyPuzzleDefinition;
+}
+
+/**
+ * Define which puzzle appears on which day by adding entries here.
+ *
+ * Resolution order for a given date:
+ *   1. the entry for that exact year-month-day;
+ *   2. the entry for the same month and day from the most recent earlier
+ *      year (so a puzzle defined once recurs annually until overridden —
+ *      entries for future years stay hidden until their year arrives);
+ *   3. the default fixed deck (DEFAULT_DAILY_PUZZLE).
+ *
+ * Examples (import GeometricDeckGenerator from "deckBuilder/GeometricDeckGenerator"
+ * or PresetDeck from "deckBuilder/PresetDeck" as needed):
+ *
+ *   "2026-10-31": {
+ *     name: "Halloween",
+ *     createDeck: () =>
+ *       new GeometricDeckGenerator(
+ *         {
+ *           shapes: ["Triangle", "Circle - Semi", "Tetris - T Block"],
+ *           colors: ["Maroon", "Olive", "Black"],
+ *           numbers: [1, 2, 3],
+ *         },
+ *         undefined,
+ *         { idPrefix: "daily-halloween" }
+ *       ),
+ *   },
+ *   "2026-12-25": {
+ *     name: "Cute Animals",
+ *     createDeck: () =>
+ *       new PresetDeck(
+ *         {
+ *           Animal: ["Cat", "Dog", "Bird"],
+ *           Hat: ["Top Hat", "Beret", "Hard Hat"],
+ *           Color: ["Black", "Orange", "White"],
+ *         },
+ *         "SD-XL/animal-hat-color",
+ *         "png"
+ *       ),
+ *   },
+ */
+export const DAILY_PUZZLE_SCHEDULE: DailyPuzzleSchedule = {};
+
+/** The deck used whenever no scheduled puzzle matches the date. */
+export const DEFAULT_DAILY_PUZZLE: DailyPuzzleDefinition = {
+  name: "Circles",
+  createDeck: createDailyDeck,
+};
+
+/**
+ * Look up the puzzle for a date in a schedule: the exact date if defined,
+ * otherwise the same month/day from the most recent earlier year, otherwise
+ * null. Future years never leak into earlier dates.
+ */
+export const resolvePuzzleForDate = (
+  schedule: DailyPuzzleSchedule,
+  dateKey: string
+): DailyPuzzleDefinition | null => {
+  if (schedule[dateKey]) {
+    return schedule[dateKey];
+  }
+  const year = Number(dateKey.slice(0, 4));
+  const monthDay = dateKey.slice(4); // "-MM-DD"
+  let bestYear = -1;
+  Object.keys(schedule).forEach((key) => {
+    if (key.slice(4) !== monthDay) {
+      return;
+    }
+    const keyYear = Number(key.slice(0, 4));
+    if (keyYear < year && keyYear > bestYear) {
+      bestYear = keyYear;
+    }
+  });
+  return bestYear >= 0 ? schedule[`${bestYear}${monthDay}`] : null;
+};
+
+/** The puzzle the daily game plays on `dateKey`. */
+export const getPuzzleForDate = (dateKey: string): DailyPuzzleDefinition =>
+  resolvePuzzleForDate(DAILY_PUZZLE_SCHEDULE, dateKey) || DEFAULT_DAILY_PUZZLE;

--- a/src/daily/scoring.ts
+++ b/src/daily/scoring.ts
@@ -1,0 +1,19 @@
+export const WRONG_GUESS_PENALTY_SECONDS = 10;
+export const HINT_PENALTY_SECONDS = 30;
+
+export interface ScoreInput {
+  elapsedSeconds: number;
+  wrongGuesses: number;
+  hintsUsed: number;
+}
+
+export const penaltySeconds = (input: {
+  wrongGuesses: number;
+  hintsUsed: number;
+}): number =>
+  input.wrongGuesses * WRONG_GUESS_PENALTY_SECONDS +
+  input.hintsUsed * HINT_PENALTY_SECONDS;
+
+/** Final score: play time plus penalty time. Lower is better. */
+export const computeScore = (input: ScoreInput): number =>
+  input.elapsedSeconds + penaltySeconds(input);

--- a/src/daily/share.ts
+++ b/src/daily/share.ts
@@ -1,0 +1,57 @@
+/** "4:32", or "1:04:32" once an hour is reached. */
+export const formatTime = (totalSeconds: number): string => {
+  const total = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const pad = (n: number): string => (n < 10 ? `0${n}` : `${n}`);
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+    : `${minutes}:${pad(seconds)}`;
+};
+
+export interface ShareInput {
+  dateKey: string;
+  scoreSeconds: number;
+  wrongGuesses: number;
+  hintsUsed: number;
+  currentStreak: number;
+}
+
+export const formatShareText = (input: ShareInput): string =>
+  [
+    `GeneralSet Daily ${input.dateKey}`,
+    `⏱️ ${formatTime(input.scoreSeconds)} (${input.wrongGuesses} wrong · ${
+      input.hintsUsed
+    } ${input.hintsUsed === 1 ? "hint" : "hints"})`,
+    `🔥 Streak: ${input.currentStreak}`,
+  ].join("\n");
+
+/**
+ * Copy text to the clipboard, trying the async clipboard API first and the
+ * legacy execCommand path second. Resolves false when both fail so the caller
+ * can fall back to showing the text for manual copy.
+ */
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (e) {
+    // fall through to the legacy path
+  }
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const succeeded = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return succeeded;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/daily/storage.ts
+++ b/src/daily/storage.ts
@@ -1,0 +1,170 @@
+import { yesterdayKey } from "./date";
+
+export interface DailyGameState {
+  dateKey: string;
+  elapsedSeconds: number;
+  wrongGuesses: number;
+  hintsUsed: number;
+  completed: boolean;
+  finalScoreSeconds: number | null;
+}
+
+export interface DailyStats {
+  completions: number;
+  currentStreak: number;
+  maxStreak: number;
+  bestScoreSeconds: number | null;
+  lastCompletedDateKey: string | null;
+}
+
+export const DEFAULT_STATS: DailyStats = {
+  completions: 0,
+  currentStreak: 0,
+  maxStreak: 0,
+  bestScoreSeconds: null,
+  lastCompletedDateKey: null,
+};
+
+const GAME_KEY = "generalset.daily.game";
+const STATS_KEY = "generalset.daily.stats";
+
+export const newGameState = (dateKey: string): DailyGameState => ({
+  dateKey,
+  elapsedSeconds: 0,
+  wrongGuesses: 0,
+  hintsUsed: 0,
+  completed: false,
+  finalScoreSeconds: null,
+});
+
+/**
+ * Fold a completion into lifetime stats. Idempotent for a day that is already
+ * recorded, so re-renders and revisits can't double count. A completion the
+ * day after the last one extends the streak; any gap restarts it.
+ */
+export const computeUpdatedStats = (
+  stats: DailyStats,
+  dateKey: string,
+  scoreSeconds: number
+): DailyStats => {
+  if (stats.lastCompletedDateKey === dateKey) {
+    return stats;
+  }
+  const currentStreak =
+    stats.lastCompletedDateKey === yesterdayKey(dateKey)
+      ? stats.currentStreak + 1
+      : 1;
+  return {
+    completions: stats.completions + 1,
+    currentStreak,
+    maxStreak: Math.max(stats.maxStreak, currentStreak),
+    bestScoreSeconds:
+      stats.bestScoreSeconds === null
+        ? scoreSeconds
+        : Math.min(stats.bestScoreSeconds, scoreSeconds),
+    lastCompletedDateKey: dateKey,
+  };
+};
+
+/** Parse stored game state; null for corrupt JSON, bad shapes, or another day's state. */
+export const parseGameState = (
+  raw: string | null,
+  dateKey: string
+): DailyGameState | null => {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      parsed.dateKey !== dateKey ||
+      typeof parsed.elapsedSeconds !== "number" ||
+      typeof parsed.wrongGuesses !== "number" ||
+      typeof parsed.hintsUsed !== "number" ||
+      typeof parsed.completed !== "boolean" ||
+      (parsed.finalScoreSeconds !== null &&
+        typeof parsed.finalScoreSeconds !== "number")
+    ) {
+      return null;
+    }
+    return {
+      dateKey: parsed.dateKey,
+      elapsedSeconds: parsed.elapsedSeconds,
+      wrongGuesses: parsed.wrongGuesses,
+      hintsUsed: parsed.hintsUsed,
+      completed: parsed.completed,
+      finalScoreSeconds: parsed.finalScoreSeconds,
+    };
+  } catch (e) {
+    return null;
+  }
+};
+
+/** Parse stored stats; DEFAULT_STATS for corrupt JSON or bad shapes. */
+export const parseStats = (raw: string | null): DailyStats => {
+  if (!raw) {
+    return DEFAULT_STATS;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      typeof parsed.completions !== "number" ||
+      typeof parsed.currentStreak !== "number" ||
+      typeof parsed.maxStreak !== "number" ||
+      (parsed.bestScoreSeconds !== null &&
+        typeof parsed.bestScoreSeconds !== "number") ||
+      (parsed.lastCompletedDateKey !== null &&
+        typeof parsed.lastCompletedDateKey !== "string")
+    ) {
+      return DEFAULT_STATS;
+    }
+    return {
+      completions: parsed.completions,
+      currentStreak: parsed.currentStreak,
+      maxStreak: parsed.maxStreak,
+      bestScoreSeconds: parsed.bestScoreSeconds,
+      lastCompletedDateKey: parsed.lastCompletedDateKey,
+    };
+  } catch (e) {
+    return DEFAULT_STATS;
+  }
+};
+
+// localStorage itself can throw (Safari private mode, storage disabled), so
+// every touch is wrapped: the game degrades to in-memory play instead of crashing.
+
+export const loadGameState = (dateKey: string): DailyGameState | null => {
+  try {
+    return parseGameState(window.localStorage.getItem(GAME_KEY), dateKey);
+  } catch (e) {
+    return null;
+  }
+};
+
+export const saveGameState = (state: DailyGameState): void => {
+  try {
+    window.localStorage.setItem(GAME_KEY, JSON.stringify(state));
+  } catch (e) {
+    // storage unavailable; play continues in memory
+  }
+};
+
+export const loadStats = (): DailyStats => {
+  try {
+    return parseStats(window.localStorage.getItem(STATS_KEY));
+  } catch (e) {
+    return DEFAULT_STATS;
+  }
+};
+
+export const saveStats = (stats: DailyStats): void => {
+  try {
+    window.localStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  } catch (e) {
+    // storage unavailable; stats lost for this session
+  }
+};

--- a/src/views/daily/game.tsx
+++ b/src/views/daily/game.tsx
@@ -5,7 +5,7 @@ import { PreviousSelection } from "components/game/previousSelection";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
 import { Set } from "set/pkg/set";
-import { createDailyDeck } from "daily/deck";
+import { getPuzzleForDate } from "daily/schedule";
 import { getDateKey, msUntilNextMidnight } from "daily/date";
 import {
   computeScore,
@@ -28,12 +28,15 @@ const GeneralSet =
   process.env.NODE_ENV !== "test" ? import("set/pkg/set") : ({} as any);
 
 const DailyGame = () => {
-  const deck = useMemo(() => createDailyDeck(), []);
+  const [dateKey, setDateKey] = useState<string>(() => getDateKey(new Date()));
+  // The scheduled puzzle for the day (or the default deck when none is
+  // defined) decides the deck and therefore the engine's dimensions.
+  const puzzle = useMemo(() => getPuzzleForDate(dateKey), [dateKey]);
+  const deck = useMemo(() => puzzle.createDeck(), [puzzle]);
   const features = deck.features.length;
   const options = deck.numOptions;
   const boardSize = features * options;
 
-  const [dateKey, setDateKey] = useState<string>(() => getDateKey(new Date()));
   // Today's saved progress, read once on mount. The engine's shuffle can't be
   // restored, so a reload deals a new board — but time and penalties resume,
   // so reloading never improves a score.
@@ -73,7 +76,9 @@ const DailyGame = () => {
     GeneralSet.then(({ Set }: any) => {
       setSet(Set.new(features, options, boardSize));
     });
-  }, [features, options, boardSize, completed]);
+    // dateKey is a dependency so switching to a new day's puzzle deals a
+    // fresh game even when the new deck has the same dimensions.
+  }, [dateKey, features, options, boardSize, completed]);
 
   useEffect(() => {
     if (completed || newDayAvailable) {
@@ -145,9 +150,8 @@ const DailyGame = () => {
     setShowResults(false);
     setNewDayAvailable(false);
     setCopied(null);
-    GeneralSet.then(({ Set }: any) => {
-      setSet(Set.new(features, options, boardSize));
-    });
+    // the engine effect re-runs off the dateKey change and deals the new
+    // day's puzzle with its own deck dimensions
   };
 
   if (!set && !completed) {
@@ -308,6 +312,10 @@ const DailyGame = () => {
                 <tr>
                   <td style={{ textAlign: "left" }}>Daily Puzzle</td>
                   <td>{dateKey}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Deck</td>
+                  <td>{puzzle.name}</td>
                 </tr>
                 <tr>
                   <td style={{ textAlign: "left" }}>Time</td>

--- a/src/views/daily/game.tsx
+++ b/src/views/daily/game.tsx
@@ -1,0 +1,362 @@
+import * as React from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Board } from "components/game/board";
+import { PreviousSelection } from "components/game/previousSelection";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import { Set } from "set/pkg/set";
+import { createDailyDeck } from "daily/deck";
+import { getDateKey, msUntilNextMidnight } from "daily/date";
+import {
+  computeScore,
+  penaltySeconds,
+  HINT_PENALTY_SECONDS,
+  WRONG_GUESS_PENALTY_SECONDS,
+} from "daily/scoring";
+import {
+  DailyStats,
+  computeUpdatedStats,
+  loadGameState,
+  loadStats,
+  newGameState,
+  saveGameState,
+  saveStats,
+} from "daily/storage";
+import { copyToClipboard, formatShareText, formatTime } from "daily/share";
+
+const GeneralSet =
+  process.env.NODE_ENV !== "test" ? import("set/pkg/set") : ({} as any);
+
+const DailyGame = () => {
+  const deck = useMemo(() => createDailyDeck(), []);
+  const features = deck.features.length;
+  const options = deck.numOptions;
+  const boardSize = features * options;
+
+  const [dateKey, setDateKey] = useState<string>(() => getDateKey(new Date()));
+  // Today's saved progress, read once on mount. The engine's shuffle can't be
+  // restored, so a reload deals a new board — but time and penalties resume,
+  // so reloading never improves a score.
+  const initial = useMemo(
+    () => loadGameState(dateKey) || newGameState(dateKey),
+    [dateKey]
+  );
+  const [elapsedSeconds, setElapsedSeconds] = useState<number>(
+    initial.elapsedSeconds
+  );
+  const [wrongGuesses, setWrongGuesses] = useState<number>(
+    initial.wrongGuesses
+  );
+  const [hintsUsed, setHintsUsed] = useState<number>(initial.hintsUsed);
+  const [completed, setCompleted] = useState<boolean>(initial.completed);
+  const [finalScoreSeconds, setFinalScoreSeconds] = useState<number | null>(
+    initial.finalScoreSeconds
+  );
+
+  const [set, setSet] = useState<Set>();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [hint, setHint] = useState<string[]>([]);
+  const [previousSelection, setPreviousSelection] = useState<string[]>([]);
+  const [message, setMessage] = useState<string>("");
+  const [setsFound, setSetsFound] = useState<number>(0);
+
+  const [stats, setStats] = useState<DailyStats>(() => loadStats());
+  const [showResults, setShowResults] = useState<boolean>(initial.completed);
+  const [newDayAvailable, setNewDayAvailable] = useState<boolean>(false);
+  const [copied, setCopied] = useState<boolean | null>(null);
+  const [countdownSeconds, setCountdownSeconds] = useState<number>(0);
+
+  useEffect(() => {
+    if (completed) {
+      return;
+    }
+    GeneralSet.then(({ Set }: any) => {
+      setSet(Set.new(features, options, boardSize));
+    });
+  }, [features, options, boardSize, completed]);
+
+  useEffect(() => {
+    if (completed || newDayAvailable) {
+      return;
+    }
+    const id = window.setInterval(() => {
+      setElapsedSeconds((seconds) => seconds + 1);
+      if (getDateKey(new Date()) !== dateKey) {
+        setNewDayAvailable(true);
+      }
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [completed, newDayAvailable, dateKey]);
+
+  useEffect(() => {
+    saveGameState({
+      dateKey,
+      elapsedSeconds,
+      wrongGuesses,
+      hintsUsed,
+      completed,
+      finalScoreSeconds,
+    });
+  }, [
+    dateKey,
+    elapsedSeconds,
+    wrongGuesses,
+    hintsUsed,
+    completed,
+    finalScoreSeconds,
+  ]);
+
+  useEffect(() => {
+    if (!showResults) {
+      return;
+    }
+    const update = () =>
+      setCountdownSeconds(Math.floor(msUntilNextMidnight(new Date()) / 1000));
+    update();
+    const id = window.setInterval(update, 1000);
+    return () => window.clearInterval(id);
+  }, [showResults]);
+
+  const finishGame = () => {
+    const score = computeScore({ elapsedSeconds, wrongGuesses, hintsUsed });
+    setCompleted(true);
+    setFinalScoreSeconds(score);
+    const updated = computeUpdatedStats(loadStats(), dateKey, score);
+    saveStats(updated);
+    setStats(updated);
+    setShowResults(true);
+  };
+
+  const startNewDay = () => {
+    const todayKey = getDateKey(new Date());
+    saveGameState(newGameState(todayKey));
+    setDateKey(todayKey);
+    setElapsedSeconds(0);
+    setWrongGuesses(0);
+    setHintsUsed(0);
+    setCompleted(false);
+    setFinalScoreSeconds(null);
+    setSet(undefined);
+    setSelected([]);
+    setHint([]);
+    setPreviousSelection([]);
+    setMessage("");
+    setSetsFound(0);
+    setShowResults(false);
+    setNewDayAvailable(false);
+    setCopied(null);
+    GeneralSet.then(({ Set }: any) => {
+      setSet(Set.new(features, options, boardSize));
+    });
+  };
+
+  if (!set && !completed) {
+    return <div>Loading...</div>;
+  }
+
+  const board = set && set.get_board() ? set.get_board().split(",") : [];
+  const cardsRemaining = set && set.get_deck() ? set.get_deck().split(",").length : 0;
+  const liveScore =
+    completed && finalScoreSeconds !== null
+      ? finalScoreSeconds
+      : computeScore({ elapsedSeconds, wrongGuesses, hintsUsed });
+
+  const selectCard = (id: string) => {
+    if (!set || completed || newDayAvailable) {
+      return;
+    }
+    const selectedClone = [...selected];
+
+    if (selectedClone.includes(id)) {
+      selectedClone.splice(selectedClone.indexOf(id), 1);
+    } else {
+      selectedClone.push(id);
+    }
+    if (selectedClone.length < options) {
+      setSelected(selectedClone);
+      return;
+    }
+
+    setHint([]);
+    setSelected([]);
+    setPreviousSelection(selectedClone);
+    if (!set.is_set(selectedClone.join(","))) {
+      setWrongGuesses(wrongGuesses + 1);
+      setMessage(`Not a set. +${WRONG_GUESS_PENALTY_SECONDS}s`);
+      return;
+    }
+
+    const next = set.update_board(selectedClone.join(","));
+    setSet(next);
+    setSetsFound(setsFound + 1);
+    setMessage("Set!");
+    if (next.is_end()) {
+      finishGame();
+    }
+  };
+
+  const giveHint = (_event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!set || completed || newDayAvailable) {
+      return;
+    }
+    setHint(set.hint(board.join(",")).split(","));
+    setHintsUsed(hintsUsed + 1);
+    setMessage(`Hint used. +${HINT_PENALTY_SECONDS}s`);
+  };
+
+  const shareText = formatShareText({
+    dateKey,
+    scoreSeconds: liveScore,
+    wrongGuesses,
+    hintsUsed,
+    currentStreak: stats.currentStreak,
+  });
+
+  const share = () => {
+    copyToClipboard(shareText).then(setCopied);
+  };
+
+  return (
+    <div>
+      <Modal show={showResults} onHide={() => setShowResults(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Daily Puzzle Complete</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <h2 style={{ textAlign: "center" }}>{formatTime(liveScore)}</h2>
+          <p style={{ textAlign: "center" }} className="text-muted">
+            {formatTime(elapsedSeconds)} +{" "}
+            {formatTime(penaltySeconds({ wrongGuesses, hintsUsed }))} in
+            penalties ({wrongGuesses} wrong · {hintsUsed}{" "}
+            {hintsUsed === 1 ? "hint" : "hints"})
+          </p>
+          <table className="table w-auto" style={{ margin: "0 auto" }}>
+            <tbody>
+              <tr>
+                <td style={{ textAlign: "left" }}>Current streak</td>
+                <td>{stats.currentStreak}</td>
+              </tr>
+              <tr>
+                <td style={{ textAlign: "left" }}>Max streak</td>
+                <td>{stats.maxStreak}</td>
+              </tr>
+              <tr>
+                <td style={{ textAlign: "left" }}>Best score</td>
+                <td>
+                  {stats.bestScoreSeconds !== null
+                    ? formatTime(stats.bestScoreSeconds)
+                    : "-"}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ textAlign: "left" }}>Puzzles completed</td>
+                <td>{stats.completions}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p style={{ textAlign: "center" }}>
+            Next puzzle in {formatTime(countdownSeconds)}
+          </p>
+          {copied === false && (
+            <textarea
+              readOnly
+              className="form-control"
+              value={shareText}
+              rows={3}
+            />
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={share}>
+            {copied ? "Copied!" : "Share"}
+          </Button>
+          <Button variant="secondary" onClick={() => setShowResults(false)}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      {newDayAvailable && (
+        <div className="alert alert-info">
+          A new daily puzzle is available.{" "}
+          <Button onClick={startNewDay}>Play today's puzzle</Button>
+        </div>
+      )}
+      <button
+        onClick={giveHint}
+        className="btn btn-secondary"
+        style={{ marginRight: "10px" }}
+        disabled={completed || newDayAvailable}
+      >
+        Hint (+{HINT_PENALTY_SECONDS}s)
+      </button>
+      {completed && (
+        <button
+          onClick={() => setShowResults(true)}
+          className="btn btn-primary"
+        >
+          Results
+        </button>
+      )}
+      <div className="container mb-2">
+        <div className="row">
+          <div className="col-sm">
+            <table
+              className="table table-borderless w-auto"
+              style={{ color: "white" }}
+            >
+              <tbody>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Daily Puzzle</td>
+                  <td>{dateKey}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Time</td>
+                  <td>{formatTime(liveScore)}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Sets Found</td>
+                  <td>{setsFound}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Cards Remaining</td>
+                  <td>{cardsRemaining}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Wrong Guesses</td>
+                  <td>{wrongGuesses}</td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "left" }}>Hints Used</td>
+                  <td>{hintsUsed}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="col-sm">
+            <PreviousSelection
+              cards={previousSelection}
+              message={message}
+              deck={deck}
+            />
+          </div>
+        </div>
+      </div>
+      {set && (
+        <Board
+          board={board}
+          selected={selected}
+          hint={hint}
+          onSelect={selectCard}
+          deck={deck}
+        />
+      )}
+      {completed && !set && (
+        <p style={{ color: "white" }}>
+          You finished today's puzzle. Come back tomorrow!
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default DailyGame;

--- a/src/views/menu.tsx
+++ b/src/views/menu.tsx
@@ -70,6 +70,13 @@ export const Menu: React.FC = () => {
         >
           Play
         </Link>
+        <Link
+          to="/daily"
+          className="btn btn-primary"
+          style={{marginTop: "10px", marginLeft: "10px"}}
+        >
+          Daily Puzzle
+        </Link>
         <h3>Images</h3>
         {StableDiffusion.map(d => (
           <Button variant="secondary" onClick={() => {setPreSetDeck(d)}} style={{margin: "5px"}} key={d.name}>


### PR DESCRIPTION
## Summary
This PR introduces a new daily puzzle game mode to GeneralSet, featuring a fixed daily deck, persistent game state, scoring with penalties, and lifetime statistics tracking.

## Key Changes

**New Daily Game View** (`src/views/daily/game.tsx`)
- Complete daily puzzle game component with timer, hint system, and results modal
- Displays game stats (time, sets found, cards remaining, wrong guesses, hints used)
- Shows results modal with lifetime statistics and countdown to next puzzle
- Share functionality to copy puzzle results to clipboard

**Game State & Statistics** (`src/daily/storage.ts`)
- Persistent localStorage-backed game state (elapsed time, wrong guesses, hints used, completion status)
- Lifetime statistics tracking (current/max streak, best score, completion count)
- Idempotent stat updates to prevent double-counting on re-renders
- Graceful degradation when localStorage is unavailable

**Scoring System** (`src/daily/scoring.ts`)
- Base score is elapsed time in seconds (lower is better)
- Wrong guess penalty: +10 seconds each
- Hint penalty: +30 seconds each
- Final score = elapsed time + penalties

**Date & Time Utilities** (`src/daily/date.ts`)
- Local timezone-aware date key generation (YYYY-MM-DD format)
- Yesterday key calculation for streak tracking (handles month/year boundaries)
- Milliseconds until next midnight calculation for puzzle unlock countdown

**Share Functionality** (`src/daily/share.ts`)
- Time formatting (M:SS or H:MM:SS format)
- Shareable text generation with emoji (puzzle date, score, wrong guesses, hints, streak)
- Clipboard copy with fallback from modern Clipboard API to legacy execCommand

**Fixed Daily Deck** (`src/daily/deck.tsx`)
- 3 features × 3 options = 27-card deck with 9-card board
- Consistent deck across all players for comparable scores
- Uses geometric shapes (circle quarters/semis) in red/olive/blue

**Comprehensive Test Coverage**
- Storage: round-trip persistence, corruption handling, streak logic
- Scoring: penalty calculations, score computation
- Date utilities: date key formatting, yesterday calculation, midnight countdown
- Share: time formatting, share text generation, clipboard operations
- Deck: fixed 27-card configuration

**UI Integration**
- Added "Daily Puzzle" button to main menu
- Updated Board and PreviousSelection components to accept optional Deck prop
- Added daily route to App.tsx router configuration

## Notable Implementation Details

- Game state persists across page reloads but deals a new board (shuffle can't be restored), so reloading never improves scores
- Streak tracking is idempotent—completing the same day multiple times doesn't double-count
- Streak resets if a day is missed, but max streak and best score are preserved
- localStorage failures gracefully degrade to in-memory play instead of crashing
- Clipboard copy tries modern Clipboard API first, falls back to execCommand, and shows textarea for manual copy if both fail
- Timer and countdown use setInterval with proper cleanup to avoid memory leaks

https://claude.ai/code/session_01Y7E6mb8tWRYBjgrAZQXYAo