### PR TITLE
Add Playwright render verification and iconography rules to the shape skill

### DIFF
--- a/.claude/skills/deckbuilder-shape/SKILL.md
+++ b/.claude/skills/deckbuilder-shape/SKILL.md
@@ -11,6 +11,8 @@ control that no other shape has (e.g. yolk count) — a new global feature.
 
 Read `references/architecture.md` first if you haven't inspected this repo's
 `src/deckBuilder` in this session. It has the facts this skill assumes.
+`references/iconography.md` has the drawing rules new shapes must follow —
+read it before you write any path data.
 
 ## 0. Locate / fetch the repo
 
@@ -27,8 +29,8 @@ From the user's description, pin down:
    once shipped, must never be renamed (deck metadata stores it).
 2. **Visual parts and their colors** — which parts use `colors.primary`,
    `colors.secondary`, `colors.tertiary`, or the resolved `fill`/pattern paint.
-   A shape that only ever shows one paint color should just use `fill` (like
-   `PathShape`) — don't hand-assign `colors.primary` for a single-region shape.
+   A shape that only ever shows one paint color should just use `fill` for its
+   base — don't hand-assign `colors.primary` for a single-region shape.
 3. **Any part that should vary per-card beyond the built-in features**
    (colors, numbers, rotations, filters, patterns) — e.g. "single/double/triple
    yolk". This needs a **new global feature** (see step 4). Ask specifically:
@@ -42,13 +44,76 @@ has two parts: yolk + white).
 
 ## 2. Write the shape component
 
-Single flat silhouette, one paint color → use the factory, nothing else needed:
+### Iconography rules (required)
+
+A card scales each symbol to **~0.22x** — `CardSvg` fits it into a 35-unit box in a
+120-unit card, and the card itself renders around 90px (60px on a short window).
+So a symbol reaches the player at roughly **26 device pixels**. Every new shape
+must be drawn for that size:
+
+1. **Bold, uniform outlines.** Every outline uses exactly
+   `stroke="#000000" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"`.
+   One width, one color, literal black — not `colors.primary`. (`stroke-width="1"`,
+   what `definePathShape` emits, is 0.22px on a card: invisible.)
+2. **Layer into `<g>` groups** — base fills, then outlines, then highlights — so
+   strokes are never buried. The resolved `fill` prop goes on the base layer only,
+   so patterns have one large area to read in.
+3. **Prefer simple geometry.** `<circle>`/`<ellipse>`/`<rect>`/`<line>` first, then
+   paths of `M`/`L`/`Q`/`T`/`Z`. Cubic `C`/`S` only when a quadratic genuinely can't
+   express the curve, and never a traced path with hundreds of points.
+4. **Draw big, inset ~6 units** so the stroke isn't shaved (usable area ≈ `6,6` →
+   `114,114`), keep every detail above ~8 units, and make sure the silhouette alone
+   distinguishes the shape from everything already in `SHAPE_REGISTRY`.
+
 ```tsx
-import { definePathShape } from "./PathShape";
-export const Star = definePathShape("M60,5 L73,40 ...");
+const Component = ({ colors, fill }: ShapeProps) => (
+  <>
+    <g stroke="none">
+      <ellipse cx="60" cy="64" rx="48" ry="42" fill={fill} />
+    </g>
+    <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="60" cy="64" rx="48" ry="42" />
+      <path d="M36,50 Q60,34 84,50" />
+    </g>
+    <g stroke="none">
+      <circle cx="42" cy="50" r="9" fill={colors.tertiary} />
+    </g>
+  </>
+);
 ```
 
-Multi-part shape with distinct colors per region → hand-written component.
+The third group is for accents drawn *on* the icon. A region that needs its own
+outline isn't a highlight: put its fill in the first group and its outline in the
+second, so the stroke still lands on top.
+
+`references/iconography.md` has the reasoning, the scale math, and a worked
+before/after. **The shapes already in the registry predate these rules and are not
+being restyled** — don't copy Tracks/Tetris/Circles/Fried Egg as style references,
+they're the problem these rules solve. Step 5 verifies the rules mechanically.
+
+### Building the component
+
+`definePathShape` strokes at `colors.primary` / width 1, which rule 1 rules out —
+it exists for the shapes already in the registry. **Write a hand-written component
+for new shapes**, even single-region ones, so the outline group can be declared:
+```tsx
+import { ShapeDefinition, ShapeProps } from "../types";
+
+const Component = ({ fill }: ShapeProps) => (
+  <>
+    <g stroke="none">
+      <path d="M60,10 L110,110 L10,110 Z" fill={fill} />
+    </g>
+    <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M60,10 L110,110 L10,110 Z" />
+    </g>
+  </>
+);
+
+export const Star: ShapeDefinition = { Component };
+```
+
+Multi-part shape with distinct colors per region → same thing with more layers.
 Follow this exact prop contract — `colors` and `fill` are supplied by
 `CardSvg`, already clamped/resolved for you:
 ```tsx
@@ -56,8 +121,16 @@ import { ShapeDefinition, ShapeProps } from "../types";
 
 const Component = ({ colors, fill }: ShapeProps) => (
   <>
-    <circle cx="60" cy="60" r="55" fill={fill} stroke={colors.primary} />
-    <circle cx="60" cy="60" r="20" fill={colors.tertiary} />
+    {/* every filled region first — the card's paint on the base, accents on top of it */}
+    <g stroke="none">
+      <circle cx="60" cy="60" r="51" fill={fill} />
+      <circle cx="60" cy="60" r="20" fill={colors.tertiary} />
+    </g>
+    {/* then one outline group over all of them */}
+    <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="60" cy="60" r="51" />
+      <circle cx="60" cy="60" r="20" />
+    </g>
   </>
 );
 
@@ -86,24 +159,37 @@ Rules:
 ```tsx
 import { ShapeDefinition, ShapeProps } from "../types";
 
-const YOLK_OFFSETS: Record<number, [number, number][]> = {
+// number[][], not [number, number][] — the pinned @typescript-eslint/parser
+// (via react-scripts 3.4.4) crashes on tuple-array types and breaks the
+// production build, which `yarn test` never sees. See commit d8701ac.
+const YOLK_OFFSETS: Record<number, number[][]> = {
   1: [[60, 60]],
   2: [[42, 55], [78, 65]],
   3: [[40, 45], [70, 40], [58, 78]],
 };
 
-const Component = ({ colors, yolks = 1 }: ShapeProps) => (
-  <>
-    <path
-      d="M60,10 C90,10 108,35 108,62 C108,92 86,110 60,110 C34,110 12,92 12,62 C12,35 30,10 60,10 Z"
-      fill={colors.secondary}
-      stroke={colors.secondary}
-    />
-    {(YOLK_OFFSETS[yolks] || YOLK_OFFSETS[1]).map(([cx, cy], i) => (
-      <circle key={i} cx={cx} cy={cy} r="14" fill={colors.primary} />
-    ))}
-  </>
-);
+// The white: a blobby outline built from quadratics, inset 6 units for the stroke.
+const WHITE = "M60,8 Q104,8 108,50 Q112,88 78,104 Q44,118 22,92 Q4,66 20,36 Q32,10 60,8 Z";
+
+const Component = ({ colors, yolks = 1 }: ShapeProps) => {
+  const centers = YOLK_OFFSETS[yolks] || YOLK_OFFSETS[1];
+  return (
+    <>
+      <g stroke="none">
+        <path d={WHITE} fill={colors.secondary} />
+        {centers.map(([cx, cy], i) => (
+          <circle key={i} cx={cx} cy={cy} r="15" fill={colors.primary} />
+        ))}
+      </g>
+      <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+        <path d={WHITE} />
+        {centers.map(([cx, cy], i) => (
+          <circle key={i} cx={cx} cy={cy} r="15" />
+        ))}
+      </g>
+    </>
+  );
+};
 
 export const FriedEgg: ShapeDefinition = {
   Component,
@@ -202,18 +288,59 @@ next person extending this can follow the same five-file recipe.
 
 ## 5. Verify
 
-From the repo root, run **both** — Jest alone won't catch type errors (see
-step 4.6):
+Three gates, all from the repo root. `node_modules` must be installed first
+(`yarn install`; use `npm install --legacy-peer-deps` if a plain `npm install`
+hits an ERESOLVE conflict on this repo's pinned
+`typescript`/`react-scripts` versions).
+
+### 5a. Look at it (the one that catches "renders, but wrong")
+
+```bash
+yarn render:shape "<Shape Name>"
+```
+
+`scripts/render-shape.mjs` renders the shape through the real `CardSvg`
+pipeline with Playwright — every option the shape's `supports` declares — and
+writes a contact-sheet PNG. It prints PASS/WARN/FAIL for what a machine can
+judge and exits non-zero on FAIL:
+
+| Check | Level | Means |
+| --- | --- | --- |
+| renders without errors | FAIL | page/console/SVG parse errors |
+| not blank | FAIL | under 1% of the card has ink — check fills, colors, coordinates |
+| fits the viewBox | FAIL | geometry is clipped (WARN if only the stroke halo is shaved — inset it) |
+| fills the viewBox | WARN | bbox spans under 55% of the box; scale the geometry up |
+| stroke survives card scale | WARN | widest stroke is under 4 user units / 1px on a 90px card (rule 1) |
+
+It also notes mixed stroke widths/colors, missing `round` caps and joins, and
+missing `<g>` grouping — the step-2 rules, reported but not gating.
+
+**Then read the printed PNG with the Read tool.** No check can tell you whether
+the shape is the thing the user asked for; that judgement is the whole point of
+the render. Look at, specifically:
+
+- **True size row** — is it recognizable at 60px, not just at 140px? This is
+  where over-detailed shapes fall apart.
+- **Zoom panel** — nothing crossing the dashed viewBox frame, outlines uniform
+  and unbroken, no detail too fine to see.
+- **Variant grid** — every pattern, rotation, and color still legible, including
+  `Black` (where a black outline merges into a dark fill) and `open` (fill
+  `none`, so only the outline holds the shape up).
+
+If it isn't right, fix the shape and re-run. **Do not present a shape whose PNG
+you have not looked at, and do not treat a green `yarn test` as evidence it
+looks right** — the tests assert markup, not appearance.
+
+### 5b. Tests and types
+
+Run **both** — Jest alone won't catch type errors (see step 4.6):
 ```bash
 CI=true yarn test src/deckBuilder --watchAll=false
 npx tsc --noEmit -p tsconfig.json   # then grep the output for deckBuilder
 ```
 (or `npm test --` / `npx` equivalents). Fix any snapshot or registry-array
 failures before presenting — a red registry test almost always means step 3's
-array edit was missed. The first `tsc` run on a fresh checkout needs
-`node_modules` installed (`npm install --legacy-peer-deps` if a plain
-`npm install` hits an ERESOLVE conflict on this repo's pinned
-`typescript`/`react-scripts` versions).
+array edit was missed.
 
 ## 6. Present
 
@@ -221,3 +348,9 @@ Show the user: the new shape file, the diffs to `shapes/index.ts` and
 `registry.test.ts`, and — if applicable — the diffs to `types.ts`,
 `features/index.ts`, and `CardSvg.tsx`. Call out the feature/shape name
 choice explicitly since both are permanent once decks are saved with them.
+
+Say that you rendered the shape and looked at the result, and list any WARNs
+you left standing with the reason they're acceptable. If the render surfaced a
+tradeoff the user should weigh — a detail that had to be dropped to stay legible
+at 26px, a silhouette close to an existing shape — raise it now rather than
+letting them find it in the game.

--- a/.claude/skills/deckbuilder-shape/references/architecture.md
+++ b/.claude/skills/deckbuilder-shape/references/architecture.md
@@ -39,5 +39,20 @@ while — this is a snapshot, not a guarantee.
   over the flag, not hardcoded to any one feature name — see
   `views/gameEditor/__tests__/GameEditor.test.tsx` for the behavior this
   guarantees.
+- **Symbols render tiny.** `CardSvg` places each symbol in a
+  `SYMBOL_SIZE = MAIN_VIEWPORT_SIZE / 3 - 5 = 35` unit box inside the 120-unit
+  card viewport — a 0.29x downscale of the shape's own `0 0 120 120` space —
+  and `src/components/game/card/index.css` caps the card at `max-height: 10vh`,
+  so a card is ~90px (~60px on a short window) and a symbol lands near 26 device
+  pixels. Combined scale from shape units to screen pixels: **~0.22x**. This is
+  the fact `references/iconography.md` exists to address, and why
+  `definePathShape`'s `strokeWidth="1"` is effectively invisible.
 - Test runner is CRA/Jest (`yarn test` / `npm test`, both wrap
-  `react-app-rewired test`).
+  `react-app-rewired test`). Tests assert markup, never appearance — the visual
+  gate is `yarn render:shape "<name>"` (`scripts/render-shape.mjs`), which
+  renders a shape through the real `CardSvg` with Playwright and writes a PNG.
+- The production build runs ESLint through `@typescript-eslint/parser@2.24.0`
+  (pinned by `react-scripts@3.4.4`), which crashes on TS tuple-array type
+  annotations like `[number, number][]`. Neither `yarn test` nor `tsc --noEmit`
+  catches it; it fails only in `yarn build` / the Netlify check. Use
+  `number[][]` instead (see commit `d8701ac`).

--- a/.claude/skills/deckbuilder-shape/references/iconography.md
+++ b/.claude/skills/deckbuilder-shape/references/iconography.md
@@ -1,0 +1,166 @@
+# Iconography rules for deckBuilder shapes
+
+**These are required for every shape added from now on.** The shapes already in
+`SHAPE_REGISTRY` (Circles, Tetris, Tracks, Triangle, Fried Egg) predate them and are
+deliberately not being restyled — they are what the rules exist to improve on, not the
+pattern to copy.
+
+## Why: a symbol is ~26 device pixels
+
+Three scale reductions stack between the coordinates you type and what a player sees:
+
+| Step | Where | Effect |
+| --- | --- | --- |
+| Shape space → symbol box | `CardSvg.tsx` — `SYMBOL_SIZE = 120/3 - 5 = 35` | **0.29x** |
+| Card viewport → card element | typical card ≈ 90px for a 120-unit viewport | **0.75x** |
+| Combined | | **≈0.22x** |
+
+Plus `src/components/game/card/index.css` caps the card at `max-height: 10vh`, so on a
+short window a card is ~60px and a symbol lands near **20px**.
+
+Concretely, in the default `0 0 120 120` shape space:
+
+- `stroke-width="1"` (what `definePathShape` emits) → **0.22px**. Invisible.
+- `stroke-width="6"` → **1.3px**. The thinnest line that reliably survives.
+- An 8-unit detail → **1.7px**. About the floor for anything you want seen.
+
+Set is a game of spotting differences fast. A symbol that needs squinting is a broken
+symbol, no matter how good it looks zoomed in.
+
+## The rules
+
+### 1. Bold, uniform outlines
+
+Every outline in the shape uses exactly:
+
+```
+stroke="#000000" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"
+```
+
+One width and one color across the whole shape. Mixed weights read as noise at 26px, and a
+black outline stays legible against every fill in `COLOR_SETS` — including the pale ones
+(`Beige`, `Mint`, `Apricot`, `Lavender`) that vanish on white without it.
+
+The outline color is a literal `#000000`, **not** `colors.primary`. The card's color
+feature varies the fills; the outline is the constant that holds the silhouette together.
+
+If your shape declares a non-default `viewBox`, scale the width to keep it at ~5% of the
+viewBox width (6/120). The render script computes the effective pixel width for you.
+
+### 2. Layer into `<g>` groups
+
+Three groups, in this order, so outlines are never buried under a later fill:
+
+```tsx
+const Component = ({ colors, fill }: ShapeProps) => (
+  <>
+    {/* 1. base fills — carries the card's resolved paint */}
+    <g stroke="none">
+      <ellipse cx="60" cy="64" rx="48" ry="42" fill={fill} />
+    </g>
+    {/* 2. outlines — one uniform stroke, no fill */}
+    <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="60" cy="64" rx="48" ry="42" />
+      <path d="M36,50 Q60,34 84,50" />
+    </g>
+    {/* 3. highlights — accents that sit on top of the outline */}
+    <g stroke="none">
+      <circle cx="42" cy="50" r="9" fill={colors.tertiary} />
+    </g>
+  </>
+);
+```
+
+The third group is for accents that read as being *on* the icon — a glint, a dot, a
+marking. A region that needs its own outline is not a highlight: put its fill in group 1
+alongside the base, and add its outline to group 2, so the stroke still lands on top.
+
+Put the resolved `fill` prop on the **base layer only**. That is the paint that carries
+striped/gradient/dotted patterns when the deck enables them, and a pattern only reads if
+it has one large uninterrupted area to fill. Highlights use `colors.secondary` /
+`colors.tertiary` so they stay distinct from the pattern.
+
+Declaring the stroke attributes once on the group — rather than per element — is what
+keeps rule 1 true as the shape grows.
+
+### 3. Prefer simple geometry
+
+In descending order of preference:
+
+1. Primitives: `<circle>`, `<ellipse>`, `<rect>`, `<line>`, `<polygon>`
+2. Paths of `M` / `L` / `Q` / `T` / `Z`
+3. Cubic `C` / `S` — only when a quadratic genuinely cannot express the curve
+
+A quadratic has one control point, so nudging a curve means moving one number. Cubics
+double the knobs for a difference nobody can see at 26px.
+
+Never paste a traced or machine-generated path. `Tracks - Deer` in `shapes/Tracks.tsx` is
+a single `d` with hundreds of points, many of them duplicates a fraction of a unit apart —
+it cannot be hand-edited, it inflates every card in the deck, and all that precision
+dissolves at card size anyway.
+
+### 4. Draw big, and leave room for the stroke
+
+Fill the viewBox, but inset ~6 units on every side so the 6-wide stroke is not shaved by
+the symbol's clip: usable area is roughly **`6,6` → `114,114`** in the default space. The
+shape's bounding box should span at least ~55% of the viewBox in its larger dimension —
+anything smaller has thrown away resolution it cannot get back.
+
+### 5. No detail below ~8 user units
+
+Whiskers, serifs, thin gaps, small notches: at 1.7px they turn into a smudge, or disappear
+into the outline. If a detail matters, make it big enough to see; if it does not, cut it.
+
+### 6. Silhouette first
+
+Fill the shape solid black in your head. Is it still identifiable, and still clearly
+different from every other entry in `SHAPE_REGISTRY`? Color, pattern, and interior detail
+are all features the deck may hold constant — the outline is the only thing guaranteed to
+distinguish two cards.
+
+## Before / after
+
+A traced icon, drawn the way it usually arrives:
+
+```tsx
+// Don't: hairline strokes, mixed weights, cubic soup, no structure.
+const Component = ({ colors, fill }: ShapeProps) => (
+  <>
+    <path
+      d="M60,14 C88,14 106,38 106,62 C106,90 84,108 60,108 C36,108 14,90 14,62 C14,38 32,14 60,14 Z"
+      fill={fill}
+      stroke={colors.primary}
+      strokeWidth="1"
+    />
+    <path d="M38,52 C46,42 54,40 60,44 C66,40 74,42 82,52" stroke={colors.tertiary} strokeWidth="2" fill="none" />
+  </>
+);
+```
+
+The same icon under these rules:
+
+```tsx
+// Do: primitives, one uniform black outline, layered groups.
+const Component = ({ colors, fill }: ShapeProps) => (
+  <>
+    <g stroke="none">
+      <circle cx="60" cy="61" r="47" fill={fill} />
+      <circle cx="60" cy="61" r="15" fill={colors.tertiary} />
+    </g>
+    <g fill="none" stroke="#000000" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="60" cy="61" r="47" />
+      <circle cx="60" cy="61" r="15" />
+      <path d="M38,52 Q60,36 82,52" />
+    </g>
+  </>
+);
+```
+
+Fewer numbers, editable by hand, and it still reads at 20px.
+
+## Checking your work
+
+`yarn render:shape "<Shape Name>"` renders the shape through the real `CardSvg` pipeline
+and reports on rules 1, 4, and 5 mechanically — effective stroke width, viewBox fit,
+bounding-box span, blank output — then writes a PNG. Rules 3 and 6 are judgement calls:
+open the PNG and look. See SKILL.md step 5.

--- a/.claude/skills/deckbuilder-shape/scripts/card-markup.tsx
+++ b/.claude/skills/deckbuilder-shape/scripts/card-markup.tsx
@@ -1,0 +1,175 @@
+/**
+ * Renders a registered deckBuilder shape to static SVG markup, using the very
+ * same `CardSvg` pipeline the app uses, and prints the result as JSON on
+ * stdout. `render-shape.mjs` spawns this under ts-node and screenshots what
+ * comes out — see that script for the whole flow.
+ *
+ * Not part of the app bundle: this lives with the deckbuilder-shape skill and
+ * is only ever run as a CLI.
+ *
+ *   TS_NODE_TRANSPILE_ONLY=1 \
+ *   TS_NODE_COMPILER_OPTIONS='{"jsx":"react","module":"commonjs","target":"es2019","esModuleInterop":true}' \
+ *   node -r ts-node/register .claude/skills/deckbuilder-shape/scripts/card-markup.tsx "Fried Egg"
+ */
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+import { CardSvg, MAIN_VIEWPORT_SIZE } from "../../../../src/deckBuilder/CardSvg";
+import { CardData, DEFAULT_CARD, NUMBERS, ROTATIONS, YOLKS } from "../../../../src/deckBuilder/features";
+import { COLOR_SETS, ColorName, clampColorSet } from "../../../../src/deckBuilder/features/colors";
+import { PATTERN_DEFS, PATTERN_NAMES, PatternName } from "../../../../src/deckBuilder/features/patterns";
+import { SHAPE_NAMES, SHAPE_REGISTRY, ShapeName } from "../../../../src/deckBuilder/shapes";
+import { Rotation } from "../../../../src/deckBuilder/types";
+
+/** Mirrors CardSvg's own symbol box: 1/3 of the card viewport, less a margin. */
+const SYMBOL_SIZE = MAIN_VIEWPORT_SIZE / 3 - 5;
+const DEFAULT_VIEW_BOX = "0 0 120 120";
+
+/** Colors worth eyeballing: a mid hue, a dark hue, and pure black (the worst
+ *  case for a black outline, which disappears into a black fill). */
+const SAMPLE_COLORS: ColorName[] = ["Red", "Blue", "Black"];
+
+/** Keep the contact sheet readable. */
+const MAX_VARIANTS = 24;
+
+const fail = (message: string): never => {
+  process.stderr.write(`${message}\n`);
+  process.exit(2);
+  throw new Error(message); // unreachable, keeps TS happy
+};
+
+const shapeName = process.argv[2];
+if (!shapeName) {
+  fail(`Usage: card-markup.tsx "<Shape Name>"\nRegistered shapes:\n  ${SHAPE_NAMES.join("\n  ")}`);
+}
+if (!(shapeName in SHAPE_REGISTRY)) {
+  fail(
+    `Unknown shape "${shapeName}".\nRegistered shapes:\n  ${SHAPE_NAMES.join("\n  ")}\n` +
+      `(Register new shapes in src/deckBuilder/shapes/index.ts before rendering them.)`
+  );
+}
+
+const name = shapeName as ShapeName;
+const shape = SHAPE_REGISTRY[name];
+const supports = shape.supports || {};
+const colorCount = supports.colors === undefined ? 3 : supports.colors;
+const viewBox = shape.viewBox || DEFAULT_VIEW_BOX;
+
+/**
+ * The option lists this shape can actually show. These repeat CardSvg's
+ * downgrade rules so the sheet never contains two cells that render
+ * identically — a grid full of duplicates hides the real variation.
+ */
+const supportedRotations = (): Rotation[] => {
+  if (supports.rotations === false) return [0];
+  if (supports.rotations === true || supports.rotations === undefined) return [...ROTATIONS];
+  return [...supports.rotations];
+};
+
+/**
+ * `solid` leads regardless of registry order: it is `DEFAULT_CARD`'s pattern
+ * and the fallback CardSvg downgrades to, so it is the honest baseline. It
+ * also matters for the checks — `open` resolves to `fill: "none"`, so a
+ * shape whose legibility comes from its fill would measure as blank.
+ */
+const supportedPatterns = (): PatternName[] => {
+  if (supports.patterns === false) return ["solid"];
+  const supported = PATTERN_NAMES.filter((pattern) => PATTERN_DEFS[pattern].colorsUsed <= colorCount);
+  return ["solid", ...supported.filter((pattern) => pattern !== "solid")];
+};
+
+const supportedYolks = (): (typeof YOLKS)[number][] => {
+  if (supports.yolks === false || supports.yolks === undefined) return [1];
+  if (supports.yolks === true) return [...YOLKS];
+  return [...supports.yolks];
+};
+
+const rotations = supportedRotations();
+const patterns = supportedPatterns();
+const yolks = supportedYolks();
+const numbers: (typeof NUMBERS)[number][] = [1, 2, 3];
+
+interface Variant {
+  label: string;
+  card: CardData;
+}
+
+/**
+ * Build the variant list breadth-first: one cell per distinct value of each
+ * axis before any combinations, so a MAX_VARIANTS truncation never drops a
+ * whole feature. The first cell is the plain baseline.
+ */
+const buildVariants = (): Variant[] => {
+  const base: CardData = {
+    ...DEFAULT_CARD,
+    shapes: name,
+    colors: SAMPLE_COLORS[0],
+    numbers: 1,
+    rotations: rotations[0],
+    patterns: patterns[0],
+    yolks: yolks[0],
+  };
+
+  const variants: Variant[] = [{ label: `${SAMPLE_COLORS[0]} · ${patterns[0]} · 1x`, card: base }];
+  const seen = new Set<string>([JSON.stringify(base)]);
+
+  const push = (label: string, overrides: Partial<CardData>) => {
+    const card: CardData = { ...base, ...overrides };
+    const key = JSON.stringify(card);
+    if (seen.has(key)) return;
+    seen.add(key);
+    variants.push({ label, card });
+  };
+
+  numbers.slice(1).forEach((n) => push(`${n} symbols`, { numbers: n }));
+  patterns.slice(1).forEach((pattern) => push(`pattern: ${pattern}`, { patterns: pattern }));
+  rotations.slice(1).forEach((rotation) => push(`rotate ${rotation}°`, { rotations: rotation }));
+  SAMPLE_COLORS.slice(1).forEach((color) => push(color, { colors: color }));
+  yolks.slice(1).forEach((count) => push(`yolks: ${count}`, { yolks: count }));
+
+  // Then a few combinations, which is where clipping and overlap show up.
+  SAMPLE_COLORS.slice(1).forEach((color) =>
+    patterns.slice(1, 3).forEach((pattern) => push(`${color} · ${pattern}`, { colors: color, patterns: pattern }))
+  );
+  rotations.slice(1, 3).forEach((rotation) => push(`3x · rotate ${rotation}°`, { numbers: 3, rotations: rotation }));
+  push("9 symbols", { numbers: 9 });
+
+  return variants.slice(0, MAX_VARIANTS);
+};
+
+const renderCard = (card: CardData, id: string): string =>
+  ReactDOMServer.renderToStaticMarkup(<CardSvg card={card} cardId={id} />);
+
+/**
+ * One symbol on its own, in the shape's own coordinate space — this is what
+ * the zoom panel shows and what the geometry checks measure. No card scaling
+ * in the way, so a bbox read off this is in raw user units.
+ */
+const renderBareSymbol = (): string => {
+  const colors = clampColorSet(COLOR_SETS[SAMPLE_COLORS[0]], colorCount);
+  const paint = PATTERN_DEFS[patterns[0]].create(colors, "bare-pattern");
+  return ReactDOMServer.renderToStaticMarkup(
+    <svg viewBox={viewBox} xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+      {paint.defs && <defs>{paint.defs}</defs>}
+      <g id="bare-symbol">
+        <shape.Component colors={colors} fill={paint.fill} yolks={yolks[0]} />
+      </g>
+    </svg>
+  );
+};
+
+process.stdout.write(
+  JSON.stringify({
+    shape: name,
+    viewBox,
+    supports,
+    colorCount,
+    symbolSize: SYMBOL_SIZE,
+    cardViewport: MAIN_VIEWPORT_SIZE,
+    axes: { numbers, patterns, rotations, colors: SAMPLE_COLORS, yolks },
+    bare: renderBareSymbol(),
+    variants: buildVariants().map((variant, index) => ({
+      label: variant.label,
+      svg: renderCard(variant.card, `v${index}`),
+    })),
+  })
+);

--- a/.claude/skills/deckbuilder-shape/scripts/render-shape.mjs
+++ b/.claude/skills/deckbuilder-shape/scripts/render-shape.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/**
+ * Renders a registered deckBuilder shape with Playwright and reports whether
+ * it is actually legible on a card.
+ *
+ *   yarn render:shape "Fried Egg"
+ *   node .claude/skills/deckbuilder-shape/scripts/render-shape.mjs "Fried Egg" --out ./somewhere
+ *
+ * It writes a contact-sheet PNG (true size / zoom / variant grid) and prints
+ * PASS·WARN·FAIL for a handful of mechanical checks. The PNG is the point:
+ * open it and confirm the shape is the thing that was asked for. The checks
+ * only catch the failures a machine can see — blank output, content spilling
+ * out of the viewBox, strokes too thin to survive the card's 0.29x downscale.
+ *
+ * Exit codes: 0 = no failures (warnings allowed), 1 = a check failed,
+ * 2 = the shape could not be rendered at all.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../../../..");
+const MARKUP_SCRIPT = path.join(HERE, "card-markup.tsx");
+
+/** Card sizes to eyeball, bracketing the app's real `max-height: 10vh` card. */
+const TRUE_SIZES = [60, 90, 140];
+/** The size the checks are stated against — a typical real card. */
+const REFERENCE_CARD_PX = 90;
+const ZOOM_PX = 240;
+const VARIANT_PX = 90;
+
+/** A stroke thinner than this many device px at REFERENCE_CARD_PX vanishes. */
+const MIN_EFFECTIVE_STROKE_PX = 1;
+/** Authored stroke width floor, in the shape's own user units (see iconography.md). */
+const MIN_AUTHORED_STROKE = 4;
+/** Below this share of lit pixels the card is effectively empty. */
+const MIN_INK_COVERAGE = 0.01;
+/** A shape spanning less than this much of its viewBox is drawn too small. */
+const MIN_BBOX_FILL = 0.55;
+
+const die = (code, ...lines) => {
+  for (const line of lines) console.error(line);
+  process.exit(code);
+};
+
+// ---------------------------------------------------------------- arguments
+
+const args = process.argv.slice(2);
+let shapeName;
+let outDir;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out") {
+    outDir = args[++i];
+  } else if (!shapeName) {
+    shapeName = args[i];
+  }
+}
+if (!shapeName) {
+  die(2, 'Usage: render-shape.mjs "<Shape Name>" [--out DIR]');
+}
+
+// ------------------------------------------------------------- dependencies
+
+if (!existsSync(path.join(REPO_ROOT, "node_modules"))) {
+  die(2, "node_modules is missing — run `yarn install` from the repo root first.");
+}
+
+let chromium;
+try {
+  ({ chromium } = await import("playwright"));
+} catch (error) {
+  die(
+    2,
+    "Could not load playwright.",
+    "Run `yarn install` (it is in devDependencies), or `yarn add --dev playwright` if it is missing.",
+    String(error.message || error)
+  );
+}
+
+// ------------------------------------------------------ render to SVG markup
+
+const markup = spawnSync(
+  process.execPath,
+  ["-r", "ts-node/register", MARKUP_SCRIPT, shapeName],
+  {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    env: {
+      ...process.env,
+      TS_NODE_TRANSPILE_ONLY: "1",
+      // Overrides the repo tsconfig, which targets es5/esnext modules for the
+      // browser build and cannot be require()d from node as-is.
+      TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+        jsx: "react",
+        module: "commonjs",
+        target: "es2019",
+        esModuleInterop: true,
+        isolatedModules: false,
+      }),
+    },
+  }
+);
+
+if (markup.error) {
+  die(2, "Failed to spawn the markup renderer.", String(markup.error.message || markup.error));
+}
+if (markup.status !== 0) {
+  die(2, markup.stderr ? markup.stderr.trimEnd() : `Markup renderer exited with ${markup.status}.`);
+}
+
+let data;
+try {
+  data = JSON.parse(markup.stdout);
+} catch {
+  die(
+    2,
+    "The markup renderer did not produce JSON. Raw output:",
+    markup.stdout.slice(0, 2000),
+    markup.stderr.slice(0, 2000)
+  );
+}
+
+const [vbMinX, vbMinY, vbWidth, vbHeight] = data.viewBox.split(/\s+/).map(Number);
+/** Shape user units -> device px on a REFERENCE_CARD_PX card. */
+const cardScale = (data.symbolSize / vbWidth) * (REFERENCE_CARD_PX / data.cardViewport);
+
+// ------------------------------------------------------------- contact sheet
+
+const escapeHtml = (value) =>
+  String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const cell = (label, svg, px) => `
+  <figure class="cell" style="--px:${px}px">
+    <div class="card">${svg}</div>
+    <figcaption>${escapeHtml(label)}</figcaption>
+  </figure>`;
+
+const html = `
+<style>
+  :root { color-scheme: light; }
+  body { margin: 0; padding: 24px; background: #f4f4f5; color: #18181b;
+         font: 13px/1.4 ui-sans-serif, system-ui, sans-serif; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .08em;
+       color: #52525b; margin: 28px 0 10px; }
+  h2:first-of-type { margin-top: 0; }
+  .row { display: flex; flex-wrap: wrap; gap: 18px; align-items: flex-end; }
+  /* Uniform card size here, so top-align keeps the grid straight when a
+     caption wraps to two lines. */
+  #variants { align-items: flex-start; }
+  .cell { margin: 0; }
+  .cell .card { width: var(--px); height: var(--px); background: #fff;
+                border: 1px solid #d4d4d8; border-radius: 4px; display: flex;
+                align-items: center; justify-content: center; }
+  /* Direct child only: CardSvg nests one sized <svg> per symbol, and a
+     descendant selector would stretch each of those to the full card. */
+  .cell .card > svg { width: 100%; height: 100%; }
+  figcaption { margin-top: 6px; font-size: 11px; color: #52525b; text-align: center;
+               max-width: var(--px); }
+  #zoom-wrap { position: relative; width: ${ZOOM_PX}px; height: ${ZOOM_PX}px;
+               background: #fff; border: 1px solid #d4d4d8;
+               background-image:
+                 linear-gradient(to right, #eee 1px, transparent 1px),
+                 linear-gradient(to bottom, #eee 1px, transparent 1px);
+               background-size: ${ZOOM_PX / 12}px ${ZOOM_PX / 12}px; }
+  #zoom-wrap > svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+  #zoom-wrap .frame { position: absolute; inset: 0; border: 2px dashed #ef4444;
+                      pointer-events: none; }
+  .legend { color: #52525b; font-size: 11px; margin-top: 8px; max-width: 480px; }
+</style>
+
+<h2>True size — the card as the app draws it</h2>
+<div class="row" id="truesize">
+  ${TRUE_SIZES.map((px) => cell(`${px}px card`, data.variants[0].svg, px)).join("")}
+  ${TRUE_SIZES.map((px) =>
+    cell(`${px}px · 3 symbols`, (data.variants.find((v) => /3 symbols/.test(v.label)) || data.variants[0]).svg, px)
+  ).join("")}
+</div>
+
+<h2>Zoom — one symbol in its own viewBox (${escapeHtml(data.viewBox)})</h2>
+<div id="zoom-wrap">
+  ${data.bare}
+  <div class="frame"></div>
+</div>
+<p class="legend">The dashed red frame is the declared viewBox. Anything touching or
+crossing it is clipped on a card. Leave ~5% inset so strokes are not cut.</p>
+
+<h2>Variants — every option this shape declares support for</h2>
+<div class="row" id="variants">
+  ${data.variants.map((variant) => cell(variant.label, variant.svg, VARIANT_PX)).join("")}
+</div>
+`;
+
+// -------------------------------------------------------------- render + check
+
+const outputDir = outDir
+  ? path.resolve(outDir)
+  : mkdtempSync(path.join(tmpdir(), "deckbuilder-render-"));
+mkdirSync(outputDir, { recursive: true });
+const slug = data.shape.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+/**
+ * Chromium builds already on the machine, newest first. Playwright only looks
+ * for the exact revision it ships with, so an environment that pre-installs
+ * browsers (CI images, sandboxes) can have a perfectly good Chromium that
+ * `chromium.launch()` refuses to use. Fall back to it rather than telling the
+ * user to download another copy.
+ */
+const findInstalledChromium = () => {
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (!root || !existsSync(root)) return null;
+  const direct = path.join(root, "chromium");
+  if (existsSync(direct) && statSync(direct).isFile()) return direct;
+  const candidates = readdirSync(root)
+    .filter((entry) => /^chromium(_headless_shell)?-\d+$/.test(entry))
+    .sort((a, b) => Number(b.match(/\d+$/)[0]) - Number(a.match(/\d+$/)[0]))
+    .flatMap((entry) => [
+      path.join(root, entry, "chrome-linux", "chrome"),
+      path.join(root, entry, "chrome-headless-shell-linux64", "chrome-headless-shell"),
+      path.join(root, entry, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium"),
+    ]);
+  return candidates.find((candidate) => existsSync(candidate)) || null;
+};
+
+const pageErrors = [];
+let browser;
+try {
+  browser = await chromium.launch();
+} catch (error) {
+  const fallback = findInstalledChromium();
+  if (!fallback) {
+    die(
+      2,
+      "Chromium failed to launch and no pre-installed browser was found.",
+      "Check PLAYWRIGHT_BROWSERS_PATH points at an existing browser install.",
+      String(error.message || error)
+    );
+  }
+  try {
+    browser = await chromium.launch({ executablePath: fallback });
+    console.error(`note: using pre-installed Chromium at ${fallback}`);
+  } catch (fallbackError) {
+    die(
+      2,
+      "Chromium failed to launch.",
+      `Also tried the pre-installed browser at ${fallback}.`,
+      String(fallbackError.message || fallbackError)
+    );
+  }
+}
+
+const page = await browser.newPage({ viewport: { width: 1100, height: 900 }, deviceScaleFactor: 2 });
+page.on("pageerror", (error) => pageErrors.push(`pageerror: ${error.message}`));
+page.on("console", (message) => {
+  if (message.type() === "error") pageErrors.push(`console: ${message.text()}`);
+});
+
+await page.setContent(html, { waitUntil: "load" });
+
+const probe = await page.evaluate(
+  async ({ cardSvg, referencePx }) => {
+    const result = { parseErrors: 0, bbox: null, strokes: [], groups: 0, coverage: null };
+
+    result.parseErrors = document.querySelectorAll("parsererror").length;
+
+    const symbol = document.querySelector("#bare-symbol");
+    if (symbol) {
+      const box = symbol.getBBox();
+      result.bbox = { x: box.x, y: box.y, width: box.width, height: box.height };
+      result.groups = symbol.querySelectorAll("g").length;
+      for (const el of symbol.querySelectorAll("*")) {
+        const style = getComputedStyle(el);
+        if (style.stroke === "none" || style.stroke === "" || Number(parseFloat(style.strokeWidth)) === 0) {
+          continue;
+        }
+        result.strokes.push({
+          tag: el.tagName,
+          stroke: style.stroke,
+          width: parseFloat(style.strokeWidth),
+          linecap: style.strokeLinecap,
+          linejoin: style.strokeLinejoin,
+        });
+      }
+    }
+
+    // Ink coverage: rasterize one card and count non-transparent pixels. A
+    // shape that renders to nothing still produces valid, passing markup.
+    try {
+      const sized = cardSvg
+        .replace(/width="[^"]*"/, `width="${referencePx}"`)
+        .replace(/height="[^"]*"/, `height="${referencePx}"`);
+      const image = new Image();
+      image.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(sized);
+      await image.decode();
+      const canvas = document.createElement("canvas");
+      canvas.width = referencePx;
+      canvas.height = referencePx;
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(image, 0, 0, referencePx, referencePx);
+      const { data: pixels } = ctx.getImageData(0, 0, referencePx, referencePx);
+      let lit = 0;
+      for (let i = 3; i < pixels.length; i += 4) {
+        if (pixels[i] > 8) lit++;
+      }
+      result.coverage = lit / (referencePx * referencePx);
+    } catch (error) {
+      result.coverage = null;
+      result.coverageError = String(error && error.message ? error.message : error);
+    }
+
+    return result;
+  },
+  { cardSvg: data.variants[0].svg, referencePx: REFERENCE_CARD_PX }
+);
+
+const sheetPath = path.join(outputDir, `${slug}.png`);
+const trueSizePath = path.join(outputDir, `${slug}-truesize.png`);
+await page.screenshot({ path: sheetPath, fullPage: true });
+const trueSizeRow = await page.$("#truesize");
+if (trueSizeRow) await trueSizeRow.screenshot({ path: trueSizePath });
+await browser.close();
+
+// ------------------------------------------------------------------- report
+
+const checks = [];
+const add = (level, name, detail) => checks.push({ level, name, detail });
+
+if (pageErrors.length || probe.parseErrors) {
+  add(
+    "FAIL",
+    "renders without errors",
+    [...pageErrors, probe.parseErrors ? `${probe.parseErrors} SVG parse error(s)` : ""]
+      .filter(Boolean)
+      .join("; ")
+  );
+} else {
+  add("PASS", "renders without errors", "no page, console, or SVG parse errors");
+}
+
+if (probe.coverage === null) {
+  add("SKIP", "not blank", `could not rasterize the card (${probe.coverageError || "unknown"})`);
+} else if (probe.coverage < MIN_INK_COVERAGE) {
+  add(
+    "FAIL",
+    "not blank",
+    `only ${(probe.coverage * 100).toFixed(2)}% of the ${REFERENCE_CARD_PX}px card has ink ` +
+      `(need ${MIN_INK_COVERAGE * 100}%) — check fills, stroke colors, and coordinates`
+  );
+} else {
+  add("PASS", "not blank", `${(probe.coverage * 100).toFixed(1)}% of the card has ink`);
+}
+
+const maxStroke = probe.strokes.reduce((max, s) => Math.max(max, s.width), 0);
+if (!probe.bbox) {
+  add("FAIL", "fits the viewBox", "could not measure the symbol — it rendered no geometry");
+} else {
+  /**
+   * `getBBox()` is the geometry alone; strokes straddle it. Geometry poking
+   * out of the viewBox is real clipping and fails. A stroke halo poking out
+   * only shaves the outline, so that warns and points at the inset rule.
+   */
+  const overflowOf = (pad) =>
+    [
+      probe.bbox.x - pad < vbMinX ? `left by ${(vbMinX - probe.bbox.x + pad).toFixed(1)}` : "",
+      probe.bbox.y - pad < vbMinY ? `top by ${(vbMinY - probe.bbox.y + pad).toFixed(1)}` : "",
+      probe.bbox.x + probe.bbox.width + pad > vbMinX + vbWidth
+        ? `right by ${(probe.bbox.x + probe.bbox.width + pad - vbMinX - vbWidth).toFixed(1)}`
+        : "",
+      probe.bbox.y + probe.bbox.height + pad > vbMinY + vbHeight
+        ? `bottom by ${(probe.bbox.y + probe.bbox.height + pad - vbMinY - vbHeight).toFixed(1)}`
+        : "",
+    ].filter(Boolean);
+
+  const geometryOverflow = overflowOf(0);
+  const strokeOverflow = overflowOf(maxStroke / 2);
+
+  if (geometryOverflow.length) {
+    add("FAIL", "fits the viewBox", `content is clipped: overflows ${geometryOverflow.join(", ")} user units`);
+  } else if (strokeOverflow.length) {
+    add(
+      "WARN",
+      "fits the viewBox",
+      `geometry fits but the stroke is shaved: overflows ${strokeOverflow.join(", ")} user units — ` +
+        `inset the shape by at least half the stroke width (~${(vbWidth * 0.05).toFixed(0)} units)`
+    );
+  } else {
+    add(
+      "PASS",
+      "fits the viewBox",
+      `bbox ${probe.bbox.width.toFixed(0)}x${probe.bbox.height.toFixed(0)} sits inside ${vbWidth}x${vbHeight} with room for the stroke`
+    );
+  }
+
+  const fillX = probe.bbox.width / vbWidth;
+  const fillY = probe.bbox.height / vbHeight;
+  if (Math.max(fillX, fillY) < MIN_BBOX_FILL) {
+    add(
+      "WARN",
+      "fills the viewBox",
+      `spans only ${(fillX * 100).toFixed(0)}% x ${(fillY * 100).toFixed(0)}% of the viewBox — ` +
+        `scale the geometry up, it shrinks another ${(data.symbolSize / vbWidth).toFixed(2)}x on a card`
+    );
+  } else {
+    add("PASS", "fills the viewBox", `spans ${(fillX * 100).toFixed(0)}% x ${(fillY * 100).toFixed(0)}% of the viewBox`);
+  }
+}
+
+if (!probe.strokes.length) {
+  add("WARN", "stroke survives card scale", "the shape has no strokes — outlines are what keep it readable at 26px");
+} else {
+  const effective = maxStroke * cardScale;
+  if (maxStroke < MIN_AUTHORED_STROKE || effective < MIN_EFFECTIVE_STROKE_PX) {
+    add(
+      "WARN",
+      "stroke survives card scale",
+      `widest stroke is ${maxStroke} user units = ${effective.toFixed(2)}px on a ${REFERENCE_CARD_PX}px card ` +
+        `(want >= ${MIN_AUTHORED_STROKE} units / ${MIN_EFFECTIVE_STROKE_PX}px — see references/iconography.md)`
+    );
+  } else {
+    add(
+      "PASS",
+      "stroke survives card scale",
+      `widest stroke is ${maxStroke} user units = ${effective.toFixed(2)}px on a ${REFERENCE_CARD_PX}px card`
+    );
+  }
+}
+
+// Non-blocking observations that mirror the authoring rules.
+const notes = [];
+if (probe.strokes.length) {
+  const widths = new Set(probe.strokes.map((s) => s.width));
+  const colors = new Set(probe.strokes.map((s) => s.stroke));
+  if (widths.size > 1) notes.push(`mixed stroke widths: ${[...widths].join(", ")} (rules ask for one uniform width)`);
+  if (colors.size > 1) notes.push(`mixed stroke colors: ${[...colors].join(", ")} (rules ask for a single outline color)`);
+  const rounded = probe.strokes.every((s) => s.linecap === "round" && s.linejoin === "round");
+  if (!rounded) notes.push('strokes are not all stroke-linecap="round" stroke-linejoin="round"');
+}
+if (!probe.groups) {
+  notes.push("no <g> groups — rules ask for layered base fill / outline / highlight groups");
+}
+
+const failures = checks.filter((c) => c.level === "FAIL").length;
+const warnings = checks.filter((c) => c.level === "WARN").length;
+
+const icon = { PASS: "✓", WARN: "!", FAIL: "✗", SKIP: "-" };
+console.log(`\n${data.shape} — ${data.variants.length} variants, viewBox "${data.viewBox}"`);
+console.log(`supports: ${JSON.stringify(data.supports)}\n`);
+for (const check of checks) {
+  console.log(`  ${icon[check.level]} ${check.level.padEnd(4)} ${check.name} — ${check.detail}`);
+}
+if (notes.length) {
+  console.log("\n  notes (not gating):");
+  for (const note of notes) console.log(`    · ${note}`);
+}
+console.log(`\n  contact sheet: ${sheetPath}`);
+console.log(`  true size:     ${trueSizePath}`);
+console.log(
+  `\n${failures} failed, ${warnings} warned. Open the contact sheet and confirm the shape ` +
+    `is what was asked for — the checks above cannot do that for you.\n`
+);
+
+process.exit(failures ? 1 : 0);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
-# react-scripts 3.4 (webpack 4) cannot build on Node >= 17 (ERR_OSSL_EVP_UNSUPPORTED)
+# react-scripts 3.4 (webpack 4) hashes with MD4, which OpenSSL 3 on Node >= 17
+# rejects as ERR_OSSL_EVP_UNSUPPORTED; --openssl-legacy-provider re-enables it.
+# Node must be >= 18 because the playwright devDependency declares
+# engines.node >= 18, and yarn 1 fails the whole install on an engines mismatch
+# ("Found incompatible module.") rather than just warning. Both settings are
+# load-bearing — dropping either one breaks the deploy.
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "20"
+  NODE_OPTIONS = "--openssl-legacy-provider"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "typescript": "~5.1.6"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired start",
-    "build": "react-app-rewired build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
     "render:shape": "node .claude/skills/deckbuilder-shape/scripts/render-shape.mjs"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "NODE_OPTIONS=--openssl-legacy-provider && react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
-    "eject": "react-app-rewired eject"
+    "eject": "react-app-rewired eject",
+    "render:shape": "node .claude/skills/deckbuilder-shape/scripts/render-shape.mjs"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -45,7 +46,9 @@
     "@types/react-redux": "^7.1.25",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-router-redux": "^5.0.22",
+    "playwright": "1.56.1",
     "react-app-rewired": "^2.2.1",
+    "ts-node": "^10.9.2",
     "wasm-loader": "^1.3.0"
   }
 }

--- a/src/deckBuilder/README.md
+++ b/src/deckBuilder/README.md
@@ -60,6 +60,33 @@ That's it — the shape shows up in the editor's Symbol list, `ShapeName` and
 registry's integrity. Registry keys are stored in saved deck metadata, so
 renaming one is a breaking change.
 
+## Legibility
+
+`CardSvg` fits each symbol into a 35-unit box in the 120-unit card viewport, and
+a card renders at roughly 90px — so a symbol reaches the player at about **26
+device pixels**. Shapes have to be drawn for that size. New shapes should:
+
+- Outline everything with one uniform
+  `stroke="#000000" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"`.
+  (`definePathShape`'s `strokeWidth="1"` works out to 0.22px on a card.)
+- Layer base fills, outlines, and highlights into separate `<g>` groups, keeping
+  the resolved `fill` paint on the base layer so patterns have room to read.
+- Favor `<circle>`/`<ellipse>`/`<rect>` and `M`/`L`/`Q`/`T` paths over cubic
+  Béziers, and never paste traced paths with hundreds of points.
+- Fill the viewBox but inset ~6 units so the stroke isn't clipped, and keep every
+  detail above ~8 units.
+
+To see what a shape actually looks like on a card:
+
+```bash
+yarn render:shape "Circle - Semi"
+```
+
+That renders the shape through `CardSvg` with Playwright at real card sizes
+across every option it supports, checks for blank output, viewBox clipping, and
+strokes too thin to survive the downscale, and writes a PNG to open. Full
+rationale in `.claude/skills/deckbuilder-shape/references/iconography.md`.
+
 ## Adding a feature
 
 Features are data-driven from `features/index.ts`: add the option type to

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -1511,6 +1518,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -1525,6 +1537,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.18"
@@ -1743,6 +1763,26 @@
   version "14.4.3"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
   integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.12.tgz#be57ceac1e4692b41be9de6be8c32a106636dba4"
+  integrity sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/aria-query@^5.0.1":
   version "5.0.1"
@@ -2265,6 +2305,13 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
+acorn-walk@^8.1.1:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -2279,6 +2326,11 @@ acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
+  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -2433,6 +2485,11 @@ aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3699,6 +3756,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -4173,6 +4235,11 @@ diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
+
+diff@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5274,6 +5341,11 @@ fsevents@2.1.2, fsevents@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^1.2.7:
   version "1.2.12"
@@ -7368,6 +7440,11 @@ make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -8443,6 +8520,20 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.56.1.tgz#24a66481e5cd33a045632230aa2c4f0cb6b1db3d"
+  integrity sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==
+
+playwright@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.56.1.tgz#62e3b99ddebed0d475e5936a152c88e68be55fbf"
+  integrity sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==
+  dependencies:
+    playwright-core "1.56.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -11041,6 +11132,25 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-pnp@1.1.6, ts-pnp@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
@@ -11331,6 +11441,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"
@@ -11930,3 +12045,8 @@ yargs@^13.3.0, yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
The deckbuilder-shape skill could only verify a new shape with `yarn test`
and `tsc --noEmit`. Both assert markup, never appearance, so a shape could
pass everything while rendering blank, clipped, or as something other than
what was asked for.

That matters more than it sounds, because symbols render tiny. CardSvg fits
each one into a 35-unit box in the 120-unit card viewport (0.29x), and
card/index.css caps the card at max-height: 10vh, so a symbol reaches the
player at roughly 26 device pixels. definePathShape's stroke-width="1" works
out to 0.22px there.

Adds a render script and the drawing rules that follow from that scale:

- scripts/card-markup.tsx renders a registered shape through the real
  CardSvg with ReactDOMServer, building a variant matrix limited to what the
  shape's `supports` declares so no two cells render alike. Follows the
  ts-node pattern export/export.ts already uses.
- scripts/render-shape.mjs drives it with Playwright: a contact sheet at
  true card sizes, a zoomed symbol against its viewBox, and the variant
  grid, plus checks for render errors, blank output, viewBox clipping,
  bounding-box span, and strokes too thin to survive the downscale. Exits
  non-zero on failure. Wired up as `yarn render:shape "<name>"`.
- references/iconography.md documents the rules new shapes must follow:
  uniform black stroke-width 6 outlines with round caps and joins, layered
  base fill / outline / highlight <g> groups, primitives and quadratic
  curves over cubic Beziers, and minimum sizes for shapes and details.
  Existing registry shapes predate these rules and are left as they are.
- SKILL.md step 5 now runs the render first and requires reading the PNG
  before presenting; architecture.md records the render-scale math and the
  tuple-array type that breaks the production build (d8701ac).

playwright is pinned to 1.56.1 to match pre-installed browser revisions;
the script falls back to any Chromium under PLAYWRIGHT_BROWSERS_PATH rather
than telling the user to download another copy.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Y5DqVuxW47sgENsRM3reS