### PR TITLE
Add GitHub Actions CI for tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn test --watchAll=false

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "NODE_OPTIONS=--openssl-legacy-provider react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "render:shape": "node .claude/skills/deckbuilder-shape/scripts/render-shape.mjs"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- Add a `.github/workflows/ci.yml` workflow that runs on push to `main` and on pull requests, with two parallel jobs: `lint` and `test`
- Add a `lint` script to `package.json` (`eslint src --ext .js,.jsx,.ts,.tsx`), reusing the existing `eslintConfig` (`extends: react-app`) — no new dependencies required since `eslint` is already pulled in transitively by `react-scripts`
- Both jobs use Node 20 with `NODE_OPTIONS=--openssl-legacy-provider` (matches the working Netlify build config, required for `react-scripts 3.4.4`/webpack 4 on modern Node/OpenSSL) and cache yarn dependencies
- `test` job runs Jest non-interactively via `yarn test --watchAll=false` with `CI=true`

## Test plan
- [x] `yarn install --frozen-lockfile` succeeds locally
- [x] `yarn lint` passes with no errors locally
- [x] `CI=true yarn test --watchAll=false` passes locally (11 test suites, 53 tests)
- [ ] GitHub Actions `lint` and `test` jobs pass on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELn9Dnq82fxAkHPJabEWSG)_