### PR TITLE
Schedule National Egg Day (June 3rd) with the Fried Egg deck

### DIFF
--- a/src/daily/__tests__/schedule.test.ts
+++ b/src/daily/__tests__/schedule.test.ts
@@ -54,13 +54,23 @@ test("an undefined day resolves to null", () => {
 });
 
 test("getPuzzleForDate falls back to the default fixed deck", () => {
-  // the checked-in schedule starts empty, so any date gets the default
-  expect(Object.keys(DAILY_PUZZLE_SCHEDULE).length).toEqual(0);
   expect(getPuzzleForDate("2026-07-28")).toBe(DEFAULT_DAILY_PUZZLE);
 });
 
 test("the default puzzle builds the fixed 27-card deck", () => {
   const deck = DEFAULT_DAILY_PUZZLE.createDeck();
+  expect(deck.features.length).toEqual(3);
+  expect(Object.keys(deck.cards).length).toEqual(27);
+});
+
+test("National Egg Day is scheduled for June 3rd and recurs annually", () => {
+  expect(getPuzzleForDate("2026-06-03").name).toEqual("National Egg Day");
+  expect(getPuzzleForDate("2027-06-03").name).toEqual("National Egg Day");
+  expect(getPuzzleForDate("2025-06-03").name).not.toEqual("National Egg Day");
+});
+
+test("National Egg Day builds a 27-card deck of Fried Egg cards", () => {
+  const deck = DAILY_PUZZLE_SCHEDULE["2026-06-03"].createDeck();
   expect(deck.features.length).toEqual(3);
   expect(Object.keys(deck.cards).length).toEqual(27);
 });

--- a/src/daily/schedule.ts
+++ b/src/daily/schedule.ts
@@ -1,4 +1,5 @@
 import { Deck } from "deckBuilder/types";
+import GeometricDeckGenerator from "deckBuilder/GeometricDeckGenerator";
 import { createDailyDeck } from "./deck";
 
 export interface DailyPuzzleDefinition {
@@ -57,7 +58,21 @@ export interface DailyPuzzleSchedule {
  *       ),
  *   },
  */
-export const DAILY_PUZZLE_SCHEDULE: DailyPuzzleSchedule = {};
+export const DAILY_PUZZLE_SCHEDULE: DailyPuzzleSchedule = {
+  "2026-06-03": {
+    name: "National Egg Day",
+    createDeck: () =>
+      new GeometricDeckGenerator(
+        {
+          numbers: [1, 2, 3],
+          yolks: [1, 2, 3],
+          colors: ["Yellow", "Orange", "Red"],
+        },
+        { shapes: "Fried Egg" },
+        { idPrefix: "daily-egg" }
+      ),
+  },
+};
 
 /** The deck used whenever no scheduled puzzle matches the date. */
 export const DEFAULT_DAILY_PUZZLE: DailyPuzzleDefinition = {


### PR DESCRIPTION
Wires up a recurring daily puzzle on June 3rd using the existing Fried
Egg shape: number of eggs (1-3), yolk count (1-3), and Yellow/Orange/Red
colors, matching the standard 3x3x3 = 27-card daily deck shape.